### PR TITLE
Remove useless comment strip

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 140
+max_line_length = 150
 
 [CHANGELOG.md]
 indent_style = space

--- a/index.js
+++ b/index.js
@@ -2,14 +2,11 @@
 
 var fnToStr = Function.prototype.toString;
 
-var constructorRegex = /^\s*class(?: |{)/;
+var constructorRegex = /^\s*class\b/;
 var isES6ClassFn = function isES6ClassFunction(value) {
 	try {
 		var fnStr = fnToStr.call(value);
-		var singleStripped = fnStr.replace(/\/\/.*\n/g, ' ');
-		var multiStripped = singleStripped.replace(/(\/\*[\w'\s\r\n*]*\*\/)|(\/\/[\w\s']*)|(<![-\-\s\w>/]*>)/g, ' ');
-		var spaceStripped = multiStripped.replace(/\n/mg, ' ').replace(/ {2}/g, ' ');
-		return constructorRegex.test(spaceStripped);
+		return constructorRegex.test(fnStr);
 	} catch (e) {
 		return false; // not a function
 	}

--- a/test.js
+++ b/test.js
@@ -45,6 +45,7 @@ var classConstructor = invokeFunction('"use strict"; return class Foo {}');
 var commentedClass = invokeFunction('"use strict"; return class/*kkk*/\n//blah\n Bar\n//blah\n {}');
 var commentedClassOneLine = invokeFunction('"use strict"; return class/**/A{}');
 var classAnonymous = invokeFunction('"use strict"; return class{}');
+var classAnonymousCommentedOneLine = invokeFunction('"use strict"; return class/*/*/{}');
 
 test('not callables', function (t) {
 	t.test('non-number/string primitives', function (st) {
@@ -146,6 +147,7 @@ test('"Class" constructors', { skip: !classConstructor || !commentedClass || !co
 	t.notOk(isCallable(commentedClass), 'class constructors with comments in the signature are not callable');
 	t.notOk(isCallable(commentedClassOneLine), 'one-line class constructors with comments in the signature are not callable');
 	t.notOk(isCallable(classAnonymous), 'anonymous class constructors are not callable');
+	t.notOk(isCallable(classAnonymousCommentedOneLine), 'anonymous one-line class constructors with comments in the signature are not callable');
 	t.end();
 });
 


### PR DESCRIPTION
I think comment strip is not necessary. I couldn't find counterexample when it's needed. Moreover it just leads to bugs. For example now `isCallable(class/*/*/{})` returns true. I've added test