### PR TITLE
[New] use `Reflect.apply`‑based callability detection

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
 	"rules": {
 		"id-length": 0,
 		"max-statements": [2, 12],
-		"max-statements-per-line": [2, { "max": 2 }]
-	}
+		"max-statements-per-line": [2, { "max": 2 }],
+		"operator-linebreak": [2, "before"],
+	},
 }

--- a/test/index.js
+++ b/test/index.js
@@ -36,8 +36,11 @@ if (typeof Proxy === 'function') {
 		proxy();
 		String(proxy);
 	} catch (_) {
-		// Older engines throw a `TypeError` when `Function.prototype.toString` is called on a Proxy object.
-		proxy = null;
+		// If `Reflect` is supported, then `Function.prototype.toString` isn't used for callability detection.
+		if (typeof Reflect !== 'object') {
+			// Older engines throw a `TypeError` when `Function.prototype.toString` is called on a Proxy object.
+			proxy = null;
+		}
 	}
 }
 


### PR DESCRIPTION
Based on the `IsConstructor` implementation in <https://github.com/ljharb/es-abstract/pull/93> and <https://github.com/tc39/ecma262/issues/1798#issuecomment-559914634>.

This makes `isCallable` use [`Reflect.apply`](https://tc39.es/ecma262/#sec-reflect.apply) with a `badArrayLike` when `Reflect.apply` and accessor descriptors are supported.

This has the advantage of supporting proxies in environments that don’t implement <https://github.com/tc39/ecma262/issues/664> (<https://github.com/tc39/ecma262/pull/697>).